### PR TITLE
Use arguments with file path

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,8 @@ Rails/LexicallyScopedActionFilter:
   Enabled: false
 Rails/Presence:
   Enabled: false
-
+Rails/FilePath:
+  EnforcedStyle: arguments
 # We should enable this later but there is currently a bug in rubocop which
 # breaks this
 # Rails/RequestReferer:


### PR DESCRIPTION
Enforce using arguments over a string, ie. `path/to/file`, for `Rails.root.join` since it's clearer how the path is getting transformed.