### PR TITLE
[Bug] rubocop-rails should be in plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,5 +40,5 @@ Layout/ExtraSpacing:
 Layout/CommentIndentation:
   Exclude:
     - 'Gemfile'
-require:
+plugins:
   - rubocop-rails

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,5 +40,5 @@ Layout/ExtraSpacing:
 Layout/CommentIndentation:
   Exclude:
     - 'Gemfile'
-plugins:
+require:
   - rubocop-rails

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ guides:
 
 ```yaml
 inherit_from:
-  - https://raw.githubusercontent.com/tyemill/ruby-style-guide/master/.rubocop.yml
-  - https://raw.githubusercontent.com/tyemill/rails-style-guide/master/.rubocop.yml
+  - https://raw.githubusercontent.com/syntax-engineering/ruby-style-guide/master/.rubocop.yml
+  - https://raw.githubusercontent.com/syntax-engineering/rails-style-guide/master/.rubocop.yml
 ```
 
 This method will cache those files locally and only update under

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ To setup Rubocop to use the most up to date configs for the current style
 guides:
 
 ```yaml
+plugins:
+  - rubocop-rails
 inherit_from:
   - https://raw.githubusercontent.com/syntax-engineering/ruby-style-guide/master/.rubocop.yml
   - https://raw.githubusercontent.com/syntax-engineering/rails-style-guide/master/.rubocop.yml
@@ -17,6 +19,8 @@ To use a local version for testing new configs or because of network issues
 ([pointing to the local paths for these files][rubocop-inheriting-configs]):
 
 ```yaml
+plugins:
+  - rubocop-rails
 inherit_from:
   - ./src/ruby-style-guide/.rubocop.yml
   - ./src/rails-style-guide/.rubocop.yml


### PR DESCRIPTION
Following

https://docs.rubocop.org/rubocop/plugin_migration_guide.html

## Pull Request Checklist
- [x] I have performed a self-review of the code
- [ ] I have added tests to prove the fix is effective or that the feature works
- [ ] I have documented this code directly or through the [engineering wiki](https://engineering-wiki.syntaxdata.com/), if necessary, such that a non-expert can understand my work.
- [x] I assert that:
  - My code is well organized, readable and robust.
  - I have considered the performance implications of these changes.
  - I have considered how this work will integrate with other tasks and features.
  - If applicable, the UI for my work matches the rest of the application or the wires, and has been tested in browser sizes targeted by this application.

## Asana Item

